### PR TITLE
Correção z-index do site e dos cards da seção front-end

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,6 +12,7 @@ html {
 :root {
     --color-black: #080808;
     --color-white: #f1f1f1;
+    --color-grayish-white: #e5e5e5;
     --color-gray-light: #d9d9d9;
     --color-gray-dark: #7b7b7b;
 }
@@ -32,6 +33,7 @@ header {
     color: var(--color-white);
     position: fixed;
     width: 100%;  
+    z-index: 999;
 }
 
 .content-container {
@@ -212,6 +214,8 @@ button {
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
+    background-color: var(--color-grayish-white);
 }
 
 .card:hover {
@@ -256,7 +260,7 @@ button {
     width: 100%;
 }
 
-
+/* Estilos do Modal */
 /* Esconde o input de controle */
 .modal-toggle {
     display: none;
@@ -326,6 +330,8 @@ button {
     background-color: var(--color-gray-dark);
 }
 
+
+/* Icones de contato */
 .contact-icons {
     display: flex;
     gap: 20px;


### PR DESCRIPTION
1 - Fiz a Correção das sobreposições dos cards sobre o header. Só precisei aplicar o z-index no header também, mas com um valor abaixo do que tava nos modais. Sobre o valor do z-index, queria saber se tem alguma regra, de centena em centena, por exemplo: z-index (modal): 1000 e z-index (header): 900

2 - Também arrumei os cards "site" da seção front-end. Removi a imagem e consegui estruturar como estava antes. Porém a forma que eu encontrei, foi: Comentar a tag "img" mas manter a div com o ".card-img". E ai no CSS só tive que aplicar um flex direction: column e um justify-content: space-between. 
Dessa forma eu entendi que ele justificou o ".card-img" e o ".card-text", mas como o "card-image" estava vazio, ele só deixou a cor de fundo, que aplique na class ".card".

3 - Quando subi o site não percebi, mas esse ajuste que mencionei acima acabou ficando aplicado só no terceiro card da seção de front. Acabei dando uns ctrl+z e não percebi que voltou essa correção q eu tinha feito nos outros cards também.

4 - Decidi subir somente assim por enquanto, pq estava tentando aplicar o "ver mais" e estava bagunçando tudo o site. Então como o git é pra isso, já vou subir com essas primeiras atualizações que estão certas, pra não correr nenhum risco kkkkkkkkk